### PR TITLE
Add billing estimation scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get install -y zip
 ADD scripts/cloudize-workflow.py /opt/scripts/cloudize-workflow.py
 ADD scripts/pull_outputs.py /opt/scripts/pull_outputs.py
 ADD scripts/requirements.txt /opt/scripts/requirements.txt
+
 # Submit workflows
 ADD scripts/workflow_options_bolton.json /opt/scripts/workflow_options_bolton.json
 ADD scripts/workflow_options_griffith.json /opt/scripts/workflow_options_griffith.json
@@ -14,10 +15,14 @@ ADD scripts/submit_workflow.sh /opt/scripts/submit_workflow.sh
 # Multi-approach help
 ADD scripts/create_service_accounts.sh /opt/scripts/create_service_accounts.sh
 ADD scripts/enable_api.sh /opt/scripts/enable_api.sh
+ADD scripts/estimate_billing.py
+ADD scripts/pull_artifacts.py
+
 # GMS setup/run
 ADD gms/resources.sh /opt/gms/resources.sh
 ADD gms/server_startup.py /opt/gms/server_startup.py
 ADD gms/start.sh /opt/gms/start.sh
+
 # Manual setup/run
 ADD manual-workflows/base_cromwell.conf /opt/manual-workflows/base_cromwell.conf
 ADD manual-workflows/helpers.sh /opt/manual-workflows/helpers.sh

--- a/manual-workflows/README.md
+++ b/manual-workflows/README.md
@@ -165,7 +165,7 @@ Example call for Somatic Exome pipeline with example data
     submit_workflow /shared/analysis-wdls/definitions/somatic_exome.wdl /shared/analysis-wdls/example-data/somatic_exome.yaml
 
 
-## Save Timing Diagram and Outputs List
+## Save Timing Diagram, Outputs, Metadata
 
 After a workflow is run, before exiting and deleting your VM, make
 sure that the timing diagram and the list of outputs are available so
@@ -179,6 +179,8 @@ be used after the VM is deleted. They can be found at paths
 
     gs://BUCKET/desired/path/WORKFLOW_ID/timing.html
     gs://BUCKET/desired/path/WORKFLOW_ID/outputs.json
+    gs://BUCKET/desired/path/metadata/WORKFLOW_ID.json
+    gs://BUCKET/desired/path/metadata/<subworkflow_ids*>.json
 
 The file `outputs.json` will simply be a map of output names to their
 GCS locations. The `pull_outputs.py` script can be used to retrieve

--- a/manual-workflows/helpers.sh
+++ b/manual-workflows/helpers.sh
@@ -29,18 +29,6 @@ function save_artifacts () {
     elif [[ $(systemctl is-active --quiet cromwell) -ne 0 ]]; then
         echo "Make sure Cromwell service is active before saving.\n\n    sudo systemctl start cromwell\n"
     else
-        echo "Cromwell server completed startup"
-        mkdir -p $WORKFLOW_ID
-        curl --fail http://localhost:8000/api/workflows/v1/$WORKFLOW_ID/timing \
-             > ${WORKFLOW_ID}/timing.html
-        if [ $? -ne 0 ]; then
-            echo "Request for timing diagram on workflow $WORKFLOW_ID failed."
-        fi
-        curl --fail http://localhost:8000/api/workflows/v1/$WORKFLOW_ID/outputs \
-             > ${WORKFLOW_ID}/outputs.json
-        if [ $? -ne 0 ]; then
-            echo "Request for outputs on workflow $WORKFLOW_ID failed."
-        fi
-        gsutil cp -r ${WORKFLOW_ID} $GCS_PATH/${WORKFLOW_ID}
+        python3 /shared/persist_artifacts.py $GCS_PATH $WORKFLOW_ID
     fi
 }

--- a/manual-workflows/server_startup.py
+++ b/manual-workflows/server_startup.py
@@ -98,6 +98,7 @@ if __name__ == '__main__':
     download_from_metadata('helpers-sh', os.path.join(SHARED_DIR, 'helpers.sh'))
     download_from_metadata('cromwell-conf', os.path.join(SHARED_DIR, 'cromwell', 'cromwell.conf'))
     download_from_metadata('workflow-options', os.path.join(SHARED_DIR, 'cromwell', 'workflow_options.json'))
+    download_from_metadata('persist-artifacts', os.path.join(SHARED_DIR, 'persist_artifacts.py'))
     start_cromwell_service()
     clone_analysis_wdls()
     print("Startup script...DONE")

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 SRC_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 show_help () {
@@ -109,7 +111,7 @@ gcloud compute instances create $INSTANCE_NAME \
        --service-account=$SERVER_ACCOUNT --scopes=cloud-platform \
        --network=default --subnet=default \
        --metadata=cromwell-version=71 \
-       --metadata-from-file=startup-script=$SRC_DIR/server_startup.py,cromwell-conf=$CROMWELL_CONF,helpers-sh=$SRC_DIR/helpers.sh,cromwell-service=$SRC_DIR/cromwell.service,workflow-options=$WORKFLOW_OPTIONS \
+       --metadata-from-file=startup-script=$SRC_DIR/server_startup.py,cromwell-conf=$CROMWELL_CONF,helpers-sh=$SRC_DIR/helpers.sh,cromwell-service=$SRC_DIR/cromwell.service,workflow-options=$WORKFLOW_OPTIONS,persist-artifacts=$SRC_DIR/../scripts/persist_artifacts.py \
        $@
 
 cat <<EOF

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,6 @@
 Some helper scripts for interacting with the Cromwell server.
 
+
 # pull\_outputs.py
 
 pull_outputs.py will query a Cromwell server for the outputs
@@ -10,6 +11,7 @@ Requirements to run this script:
  - able to reach the Cromwell server's endpoints
  - authenticated by Google
  - authorized to read files from specified GCS bucket
+
 
 # cloudize-workflow.py
 
@@ -25,7 +27,8 @@ Requirements to run this script:
  - authenticated by Google
  - authorized to write files to specified GCS bucket
 
-# submit_workflow.sh
+
+# submit\_workflow.sh
 
 This script is the least user-ready script but it's still available
 as-needed. It's essentially just composing the steps "zip the workflow
@@ -40,3 +43,31 @@ Given the location of a workflow definition, perform a zip on a
 pre-defined location for WDL workflows (ANALYSIS\_WDLS), then curl with
 those inputs, the newly generated zip, and a pre-defined
 WORKFLOW\_OPTIONS file.
+
+
+# estimate\_billing.py
+
+This script generates a JSON file which estimates the cost of a
+workflow run. Takes both a root workflow_id to estimate, and a path to
+a directory with a pile of JSON files named
+`<workflow_id>.json`. These are generated with `persist_artifacts.py`
+which saves them both locally and in GCS. `estimate_billing.py` works
+for either local or GCS paths, but if you want to run multiple times
+you should probably get local copies first and run them on that.
+
+Estimation is done by crawling the metadata.json files of the root
+workflow, and any of its subworkflows, to find the VM characteristics
+for each call. Cost of a task is roughly
+
+    (cost_vm_cpu + cost_vm_ram + cost_disks) * duration
+
+Outputs to stdout in JSON format. You'll want to call with `>
+costs.json` or similar. Each workflow has its total cost, start/end
+times, duration, and its calls (tasks + workflows) costs. Each task
+has its total cost, start/end times, duration, machine type, disks,
+and prices.
+
+
+See the Google docs for pricing information
+- VM: https://cloud.google.com/compute/vm-instance-pricing
+- disks: https://cloud.google.com/compute/disks-image-pricing#disk

--- a/scripts/estimate_billing.py
+++ b/scripts/estimate_billing.py
@@ -1,0 +1,183 @@
+import json
+import logging
+import os
+import requests
+
+from argparse import ArgumentParser
+from datetime import datetime
+from pathlib import Path
+
+from google.cloud import storage
+
+
+# Tasks:
+# - calculate CURRENT costs for orchestration VM where this script is being run
+# - get cost of all tasks in a metadata.json file
+# - get all subworkflows in a metadata.json, recurse on their metadata.json files
+# - collect recursively-gathered task costs to a list
+# - use gathered list + orchestration to find total price of workflow
+
+# Improvements:
+# - costs from a google-provided csv
+
+TASK_KEY = "jes"
+SUBWORKFLOW_KEY = "subWorkflowId"
+
+# GOOGLE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+# requests.get(GOOGLE_URL, headers={'Metadata-Flavor': 'Google'})
+
+
+GCS = storage.Client()
+def gcs_blob(path):
+    bucket, *path = filename.split("/")[2:]
+    return GCS.get_bucket(bucket).get_blob("/".join(path))
+
+
+def read_json(filename):
+    """
+    read+parse a JSON file into memory. Works for local and gs:// files
+    """
+    if filename.startswith("gs://"):
+        return json.loads(gcs_blob(filename).download_as_text())
+    else:
+        with open(filename) as f:
+            return json.load(f)
+
+
+def is_subworkflow(call):
+    return SUBWORKFLOW_KEY in call
+
+
+def is_run_task(call):
+    return TASK_KEY in call
+
+
+def is_cached_task(call):
+    return ("callCaching" in call and call["callCaching"]["hit"])
+
+
+def from_iso(datetime_str):
+    return datetime.fromisoformat(datetime_str.rstrip('Z'))
+
+
+N1_PREEMPTIBLE_MACHINE_PRICE = {
+    "memory": 0.000892, "cpu": 0.006655
+}
+N1_MACHINE_PRICE = {
+    "memory": 0.004237, "cpu": 0.031611
+}
+# TODO(john) zones/regions also matter
+def cost_machine_type(machine_type, duration_seconds, preemptible = False):
+    """
+    Calculate the per-minute cost of a machine type.
+
+    Pricing is explained in detail at this page: https://cloud.google.com/compute/vm-instance-pricing
+    Cromwell (at least in Feb2022) defaults to N1 instances for all tasks.
+    """
+    if machine_type.startswith("custom-"):
+        vcpus, memory_mb = [int(x) for x in machine_type.split('-')[1:]]
+        memory_gb = memory_mb / 2**10
+        price = N1_PREEMPTIBLE_MACHINE_PRICE if preemptible else N1_MACHINE_PRICE
+        return {"cpu":    duration_seconds * vcpus * price["cpu"] / 60,
+                "memory": duration_seconds * memory_gb * price["memory"] / 60}
+    else:
+        raise NotImplementedError(f"Don't know how to handle machine type {machine_type}")
+
+
+# TODO(john) zones/regions also matter
+SECONDS_PER_MONTH = 30 * 24 * 60 * 60
+DISK_PRICE = { "SSD": 0.170, "HDD": 0.040 }
+def cost_disks(disks, duration_seconds):
+    """
+    Calculate the per-minute cost of disks used by the VM.
+
+    Pricing is explained in detail at this page:
+    https://cloud.google.com/compute/disks-image-pricing#disk
+    """
+    if len(disks.split(" ")) != 3:
+        raise NotImplementedError(f"Not handling multiple disks yet. {disks}")
+
+    total_gb, disk_type = disks.split(" ")[1:]
+
+    if disk_type not in DISK_PRICE:
+        raise NotImplementedError(f"Don't know what to do with disk type {disk_type} for disks: {disks}")
+    else:
+        return duration_seconds * int(total_gb) * DISK_PRICE[disk_type] / SECONDS_PER_MONTH
+
+
+def cost_task(task):
+    """
+    Calculate the total cost to run this task.
+
+    Returns that total and the values used to calculate it.
+    """
+    assert is_run_task(task)
+    # TODO(john): calculate based on events for more accuracy. We're overestimating right now.
+    start_time, end_time = task["start"], task["end"]
+
+    duration = (from_iso(end_time) - from_iso(start_time)).seconds
+
+    machine_type = task["jes"]["machineType"]
+    preemptible = task["runtimeAttributes"]["preemptible"]
+    disks_used = task["runtimeAttributes"]["disks"]
+
+    machine_cost = cost_machine_type(machine_type, duration, preemptible=preemptible)
+    disk_cost = cost_disks(disks_used, duration)
+    total_cost = machine_cost["cpu"] + machine_cost["memory"] + disk_cost
+
+    return {
+        "durationSeconds": duration,
+        "startTime": start_time,
+        "endTime": end_time,
+        "machineType": machine_type,
+        "memoryCost": machine_cost["memory"],
+        "cpuCost": machine_cost["cpu"],
+        "diskCost": disk_cost,
+        "disks": disks_used,
+        "totalCost": total_cost
+    }
+
+
+def cost_workflow(location, workflow_id):
+    """
+    Determine the totalcost of a workflow.
+
+    Returns total cost, call costs, and start/end time.
+    """
+    metadata = read_json(f"{Path(location)}/{workflow_id}.json")
+    call_costs_by_name = {}
+    for call_name, calls in metadata["calls"].items():
+        for idx, call in enumerate(calls):
+            call_key = call_name if idx == -1 else f"{call_name}_shard-{idx}"
+            if is_run_task(call):
+                cost = cost_task(call)
+                call_costs_by_name[call_key] = cost
+            elif is_cached_task(call):
+                logging.info(f"Skipping CACHED {call_name}")
+            elif is_subworkflow(call):
+                cost = cost_workflow(location, call["subWorkflowId"])
+                call_costs_by_name[call_key] = cost
+            else:
+                logging.warning(f"Not a vm, cacheHit, or subworkflow. Failed before VM start? {call_name} {idx}")
+    return {
+        "callCosts": call_costs_by_name,
+        "totalCost": sum(call["totalCost"] for call in call_costs_by_name.values()),
+        "startTime": metadata["start"],
+        "endTime": metadata["end"],
+    }
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Generate JSON of billing information for workflow, using local metadata files.")
+    parser.add_argument("workflow_id")
+    parser.add_argument("metadata_dir")
+    args = parser.parse_args()
+
+    log_level = os.environ.get("LOGLEVEL", "WARNING").upper()
+    logging.basicConfig(
+        level=log_level,
+        format='[%(levelname)s] %(message)s'
+    )
+
+    cost = cost_workflow(args.metadata_dir, args.workflow_id)
+    print(cost)

--- a/scripts/estimate_billing.py
+++ b/scripts/estimate_billing.py
@@ -10,25 +10,40 @@ from pathlib import Path
 from google.cloud import storage
 
 
-# Tasks:
-# - calculate CURRENT costs for orchestration VM where this script is being run
-# - get cost of all tasks in a metadata.json file
-# - get all subworkflows in a metadata.json, recurse on their metadata.json files
-# - collect recursively-gathered task costs to a list
-# - use gathered list + orchestration to find total price of workflow
-
 # Improvements:
+# - optionally determine cost of VM this script runs in. Used for GMS
 # - costs from a google-provided csv
 
 TASK_KEY = "jes"
 SUBWORKFLOW_KEY = "subWorkflowId"
+
+SECONDS_PER_HOUR = 60 * 60
+SECONDS_PER_MONTH = 30 * 24 * SECONDS_PER_HOUR
+
+# Compute VM prices are priced per hour used.
+# Charges are done once per second, with a minimum of one minute
+# https://cloud.google.com/compute/vm-instance-pricing#billingmodel
+# Values taken February 21, 2022. Values change constantly.
+# TODO(john) pull price values from a real data source
+N1_PREEMPTIBLE_MACHINE_PRICE = {
+    "memory": 0.00094, "cpu": 0.00698
+}
+N1_MACHINE_PRICE = {
+    "memory": 0.004446, "cpu": 0.033174
+}
+
+# Disks are priced per month used, in granularity of seconds
+# Values taken February 21, 2022. Values change constantly.
+# TODO(john) pull price values from a real data source
+DISK_PRICE = { "SSD": 0.170, "HDD": 0.040 }
+
 
 # GOOGLE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/attributes"
 # requests.get(GOOGLE_URL, headers={'Metadata-Flavor': 'Google'})
 
 
 GCS = storage.Client()
-def gcs_blob(path):
+def gcs_blob(filename):
     bucket, *path = filename.split("/")[2:]
     return GCS.get_bucket(bucket).get_blob("/".join(path))
 
@@ -37,6 +52,7 @@ def read_json(filename):
     """
     read+parse a JSON file into memory. Works for local and gs:// files
     """
+    logging.debug(f"Reading JSON {filename}")
     if filename.startswith("gs://"):
         return json.loads(gcs_blob(filename).download_as_text())
     else:
@@ -60,13 +76,6 @@ def from_iso(datetime_str):
     return datetime.fromisoformat(datetime_str.rstrip('Z'))
 
 
-N1_PREEMPTIBLE_MACHINE_PRICE = {
-    "memory": 0.000892, "cpu": 0.006655
-}
-N1_MACHINE_PRICE = {
-    "memory": 0.004237, "cpu": 0.031611
-}
-# TODO(john) zones/regions also matter
 def cost_machine_type(machine_type, duration_seconds, preemptible = False):
     """
     Calculate the per-minute cost of a machine type.
@@ -78,15 +87,12 @@ def cost_machine_type(machine_type, duration_seconds, preemptible = False):
         vcpus, memory_mb = [int(x) for x in machine_type.split('-')[1:]]
         memory_gb = memory_mb / 2**10
         price = N1_PREEMPTIBLE_MACHINE_PRICE if preemptible else N1_MACHINE_PRICE
-        return {"cpu":    duration_seconds * vcpus * price["cpu"] / 60,
-                "memory": duration_seconds * memory_gb * price["memory"] / 60}
+        return {"cpu":    min(60, duration_seconds) * vcpus * price["cpu"] / SECONDS_PER_HOUR,
+                "memory": min(60, duration_seconds) * memory_gb * price["memory"] / SECONDS_PER_HOUR}
     else:
         raise NotImplementedError(f"Don't know how to handle machine type {machine_type}")
 
 
-# TODO(john) zones/regions also matter
-SECONDS_PER_MONTH = 30 * 24 * 60 * 60
-DISK_PRICE = { "SSD": 0.170, "HDD": 0.040 }
 def cost_disks(disks, duration_seconds):
     """
     Calculate the per-minute cost of disks used by the VM.
@@ -115,18 +121,20 @@ def cost_task(task):
     # TODO(john): calculate based on events for more accuracy. We're overestimating right now.
     start_time, end_time = task["start"], task["end"]
 
-    duration = (from_iso(end_time) - from_iso(start_time)).seconds
+    duration = from_iso(end_time) - from_iso(start_time)
+    total_seconds = duration.total_seconds()
 
     machine_type = task["jes"]["machineType"]
     preemptible = task["runtimeAttributes"]["preemptible"]
     disks_used = task["runtimeAttributes"]["disks"]
 
-    machine_cost = cost_machine_type(machine_type, duration, preemptible=preemptible)
-    disk_cost = cost_disks(disks_used, duration)
+    machine_cost = cost_machine_type(machine_type, total_seconds, preemptible=preemptible)
+    disk_cost = cost_disks(disks_used, total_seconds)
     total_cost = machine_cost["cpu"] + machine_cost["memory"] + disk_cost
 
     return {
-        "durationSeconds": duration,
+        "durationSeconds": total_seconds,
+        "duration": str(duration),
         "startTime": start_time,
         "endTime": end_time,
         "machineType": machine_type,
@@ -144,11 +152,11 @@ def cost_workflow(location, workflow_id):
 
     Returns total cost, call costs, and start/end time.
     """
-    metadata = read_json(f"{Path(location)}/{workflow_id}.json")
+    metadata = read_json(f"{location}/{workflow_id}.json")
     call_costs_by_name = {}
     for call_name, calls in metadata["calls"].items():
         for idx, call in enumerate(calls):
-            call_key = call_name if idx == -1 else f"{call_name}_shard-{idx}"
+            call_key = call_name if call["shardIndex"] == -1 else f"{call_name}_shard-{idx}"
             if is_run_task(call):
                 cost = cost_task(call)
                 call_costs_by_name[call_key] = cost
@@ -159,11 +167,14 @@ def cost_workflow(location, workflow_id):
                 call_costs_by_name[call_key] = cost
             else:
                 logging.warning(f"Not a vm, cacheHit, or subworkflow. Failed before VM start? {call_name} {idx}")
+    duration = from_iso(metadata["end"]) - from_iso(metadata["start"])
     return {
         "callCosts": call_costs_by_name,
         "totalCost": sum(call["totalCost"] for call in call_costs_by_name.values()),
         "startTime": metadata["start"],
         "endTime": metadata["end"],
+        "duration": str(duration),
+        "durationSeconds": duration.total_seconds()
     }
 
 
@@ -173,11 +184,11 @@ if __name__ == "__main__":
     parser.add_argument("metadata_dir")
     args = parser.parse_args()
 
-    log_level = os.environ.get("LOGLEVEL", "WARNING").upper()
+    log_level = os.environ.get("LOGLEVEL", "INFO").upper()
     logging.basicConfig(
         level=log_level,
         format='[%(levelname)s] %(message)s'
     )
 
-    cost = cost_workflow(args.metadata_dir, args.workflow_id)
-    print(cost)
+    cost = cost_workflow(args.metadata_dir.rstrip('/'), args.workflow_id)
+    print(json.dumps(cost, indent=4))

--- a/scripts/estimate_billing.py
+++ b/scripts/estimate_billing.py
@@ -77,7 +77,9 @@ def cost_machine_type(machine_type, duration_seconds, preemptible = False):
     """
     Calculate the per-minute cost of a machine type.
 
-    Pricing is explained in detail at this page: https://cloud.google.com/compute/vm-instance-pricing
+    Pricing is explained in detail at this page:
+    https://cloud.google.com/compute/vm-instance-pricing
+
     Cromwell (at least in Feb2022) defaults to N1 instances for all tasks.
     """
     if machine_type.startswith("custom-"):

--- a/scripts/persist_artifacts.py
+++ b/scripts/persist_artifacts.py
@@ -1,0 +1,74 @@
+import json
+import logging
+import os
+import requests
+
+from argparse import ArgumentParser
+
+
+CROMWELL_API = "http://localhost:8000/api"
+
+
+def _save_locally(contents, filename):
+    with open(filename, "w") as f:
+        json.dump(contents, f)
+
+
+def _save_gcs(src, dest):
+    logging.info(f"Saving {src} to {dest}")
+    os.system(f"gsutil -q cp {src} {dest}")
+
+
+def _request_workflow(endpoint):
+    return requests.get(f"{CROMWELL_API}/workflows/v1/{endpoint}")
+
+
+def _persist_endpoint(endpoint, gcs_dir, filename):
+    response = _request_workflow(endpoint)
+    if response.ok:
+        _save_locally(response.text, filename)
+        _save_gcs(filename, f"{gcs_dir}/{filename}")
+    else:
+        logging.error(f"{endpoint} returned non-OK response {response}")
+
+
+def save_timing(workflow_id, gcs_dir):
+    _persist_endpoint(f"{workflow_id}/timing", gcs_dir, "timing.html")
+
+
+def save_outputs(workflow_id, gcs_dir):
+    _persist_endpoint(f"{workflow_id}/outputs", gcs_dir, "outputs.html")
+
+
+def save_metadata(workflow_id, gcs_dir):
+    """
+    Save `metadata` for workflow_id and its subworkflows to `gcs_dir`
+    """
+    response = _request_workflow(f"{workflow_id}/metadata")
+    if response.ok:
+        _save_locally(response.text, f"{workflow_id}.json")
+        _save_gcs(f"{workflow_id}.json", f"{gcs_dir}/{workflow_id}.json")
+        metadata = response.json()
+        for k, calls in metadata.get("calls", {}).items():
+            for call in calls:
+                if "subWorkflowId" in call:
+                    save_metadata(call["subWorkflowId"], gcs_dir)
+    else:
+        logging.error(f"{workflow_id}/metadata endpoint returned non-OK response {response}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Upload Cromwell endpoint responses for a given workflow. Uploads timing, outputs, and metadata (including subworkflow metadata).")
+    parser.add_argument("gcs_dir", required=True)
+    parser.add_argument("workflow_id", required=True)
+    args = parser.parse_args()
+
+    log_level = os.environ.get("LOGLEVEL", "WARNING").upper()
+    logging.basicConfig(
+        level=log_level,
+        format='[%(levelname)s] %(message)s'
+    )
+
+    save_timing(args.workflow_id, args.gcs_dir)
+    save_outputs(args.workflow_id, args.gcs_dir)
+    save_metadata(args.workflow_id, f"{args.gcs_dir}/metadata")


### PR DESCRIPTION
We want to be able to estimate GCP costs for a workflow and there doesn't seem to be a good way to do this without
A) going through Terra estimators which are pre-run, not post-run
B) going through GCP billing data, which isn't able to be shared to several projects within an organization

Improvements that could still be made:
1) make following cache calls optional, i.e. "i only care about the cost of this command" vs "i only care about the cost to run this workflow" 
2) include this in GMS integration so it happens at shutdown step
Improvement (2) soon to follow, (1) only if requested
