### PR TITLE
Fixing Issues #23, #20, and #21

### DIFF
--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -36,7 +36,6 @@ if [[ ($COMMAND != "init-project") && ($COMMAND != "generate-config")]]; then
     die "ERROR: invalid command - $COMMAND"
 fi
 
-
 while test $# -gt 0; do
     case $1 in
         -h|--help)

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -5,7 +5,7 @@ SRC_DIR=$(dirname "$0")
 function show_help {
     echo "$0 - Create/Destroy resources for manual Cromwell workflow execution"
     echo ""
-    echo "usage: sh $0 COMMAND --config-dir <DIR> --project <PROJECT> --bucket <BUCKET> --cidr <CIDR> --gc-region <REGION>"
+    echo "usage: sh $0 COMMAND --config-dir <DIR> --project <PROJECT> --bucket <BUCKET> --ip-range <RANGE> --gc-region <REGION>"
     echo ""
     echo "commands:"
     echo "    init-project        Create required resources for the project. You'll almost always want this one."
@@ -66,11 +66,11 @@ while test $# -gt 0; do
                 shift
             fi
             ;;
-	--cidr*)
+	--ip-range*)
 	    if [ ! "$2" ]; then
-		die 'ERROR: "--cidr" requires a non-empty argument.'
+		die 'ERROR: "--ip-range" requires a non-empty argument.'
 	    else
-		CIDR=$2
+		IP_RANGE=$2
 		shift
 	    fi
 	    ;;
@@ -98,8 +98,8 @@ fi
 if [ -z $BUCKET ]; then
     die 'ERROR: "--bucket" must be set.'
 fi
-if [ -z $CIDR ]; then
-    die 'ERROR: "--CIDR" must be set.'
+if [ -z $IP_RANGE ]; then
+    die 'ERROR: "--ip-range" must be set.'
 fi
 if [ -z $GC_REGION ]; then
     GC_REGION="us-central1"
@@ -137,7 +137,7 @@ sh $SRC_DIR/../scripts/enable_api.sh
 case $COMMAND in
     "init-project")
         # Create service accounts
-        sh $SRC_DIR/../scripts/create_resources.sh $PROJECT $SERVER_NAME $COMPUTE_NAME $BUCKET $CIDR $GC_REGION
+        sh $SRC_DIR/../scripts/create_resources.sh $PROJECT $SERVER_NAME $COMPUTE_NAME $BUCKET $IP_RANGE $GC_REGION
         # Create bucket if not exists
         # Generate cromwell.conf
         generate_config

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -18,7 +18,8 @@ function show_help {
     echo "    --bucket       name for the GCS bucket used by Cromwell"
     echo "    --project      name of your GCP project"
     echo "    --ip-range     block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
-    echo "    --gc-region    DEFAULT='us-central1'. For other regions check: https://cloud.google.com/compute/docs/regions-zones" 
+    echo "    --gc-region    DEFAULT='us-central1'. For other regions, check: https://cloud.google.com/compute/docs/regions-zones"
+    echo "    --retention    DEFAULT is 30d. For more option, check: https://cloud.google.com/storage/docs/gsutil/commands/mb#retention-policy"
     echo ""
 }
 
@@ -82,7 +83,15 @@ while test $# -gt 0; do
 		shift
 	    fi
        	    ;;
-        *)
+	--retention*)
+	    if [ ! "$2" ]; then
+		RETENTION="30d"
+	    else
+		RETENTION=$2
+		shift
+	    fi
+       	    ;;
+         *)
             break
             ;;
     esac
@@ -103,6 +112,9 @@ if [ -z $IP_RANGE ]; then
 fi
 if [ -z $GC_REGION ]; then
     GC_REGION="us-central1"
+fi
+if [ -z $RETENTION ]; then
+    RETENTION="30d"
 fi
 
 COMPUTE_NAME="cromwell-compute"
@@ -137,7 +149,7 @@ sh $SRC_DIR/../scripts/enable_api.sh
 case $COMMAND in
     "init-project")
         # Create service accounts
-        sh $SRC_DIR/../scripts/create_resources.sh $PROJECT $SERVER_NAME $COMPUTE_NAME $BUCKET $IP_RANGE $GC_REGION
+        sh $SRC_DIR/../scripts/create_resources.sh $PROJECT $SERVER_NAME $COMPUTE_NAME $BUCKET $IP_RANGE $GC_REGION $RETENTION
         # Create bucket if not exists
         # Generate cromwell.conf
         generate_config

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -5,7 +5,7 @@ SRC_DIR=$(dirname "$0")
 function show_help {
     echo "$0 - Create/Destroy resources for manual Cromwell workflow execution"
     echo ""
-    echo "usage: sh $0 COMMAND --config-dir <DIR> --project <PROJECT> --bucket <BUCKET> --ip-range <RANGE> --gc-region <REGION>"
+    echo "usage: sh $0 COMMAND --project <PROJECT> --bucket <BUCKET> --ip-range <RANGE>"
     echo ""
     echo "commands:"
     echo "    init-project        Create required resources for the project. You'll almost always want this one."
@@ -17,7 +17,7 @@ function show_help {
     echo "    --config-dir   a dir path that is writable, DEFAULT='\$SRC_DIR'"
     echo "    --bucket       name for the GCS bucket used by Cromwell"
     echo "    --project      name of your GCP project"
-    echo "    --ip-range         block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
+    echo "    --ip-range     block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
     echo "    --gc-region    DEFAULT='us-central1'. For other regions check: https://cloud.google.com/compute/docs/regions-zones" 
     echo ""
 }

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -68,7 +68,7 @@ while test $# -gt 0; do
             ;;
 	--cidr*)
 	    if [ ! "$2" ]; then
-		die 'ERROR: "--CIDR" requires a non-empty argument.'
+		die 'ERROR: "--cidr" requires a non-empty argument.'
 	    else
 		CIDR=$2
 		shift

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -19,7 +19,7 @@ function show_help {
     echo "    --project      name of your GCP project"
     echo "    --ip-range     block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
     echo "    --gc-region    DEFAULT='us-central1'. For other regions, check: https://cloud.google.com/compute/docs/regions-zones"
-    echo "    --retention    DEFAULT is 30d. For more option, check: https://cloud.google.com/storage/docs/gsutil/commands/mb#retention-policy"
+    echo "    --retention    DEFAULT is none. For more option, check: https://cloud.google.com/storage/docs/gsutil/commands/mb#retention-policy"
     echo ""
 }
 
@@ -85,7 +85,7 @@ while test $# -gt 0; do
        	    ;;
 	--retention*)
 	    if [ ! "$2" ]; then
-		RETENTION="30d"
+		RETENTION=""
 	    else
 		RETENTION=$2
 		shift
@@ -114,7 +114,7 @@ if [ -z $GC_REGION ]; then
     GC_REGION="us-central1"
 fi
 if [ -z $RETENTION ]; then
-    RETENTION="30d"
+    RETENTION=""
 fi
 
 COMPUTE_NAME="cromwell-compute"

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -17,7 +17,7 @@ function show_help {
     echo "    --config-dir   a dir path that is writable, DEFAULT='\$SRC_DIR'"
     echo "    --bucket       name for the GCS bucket used by Cromwell"
     echo "    --project      name of your GCP project"
-    echo "    --cidr         block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
+    echo "    --ip-range         block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
     echo "    --gc-region    DEFAULT='us-central1'. For other regions check: https://cloud.google.com/compute/docs/regions-zones" 
     echo ""
 }

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -113,7 +113,7 @@ SERVER_ACCOUNT="$SERVER_NAME@$PROJECT.iam.gserviceaccount.com"
 
 function generate_config {
     cp $SRC_DIR/base_cromwell.conf $CONFIG_DIR/cromwell.conf
-    cat << EOF >> $/cromwell.conf
+    cat << EOF >> $CONFIG_DIR/cromwell.conf
 backend.providers.default.config {
     project = "$PROJECT"
     root = "gs://$BUCKET/cromwell-executions"

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -14,8 +14,8 @@ arguments:
 -h, --help           print this block and immediately exits
 --project            GCP project name
 --server-account     Email identifier of service account used by main Cromwell instance
---cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT $SRC_DIR/cromwell.conf
---workflow-options   Local path to `workflow_options.json`. DEFAULT $SRC_DIR/workflow_options.json
+--cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT \$SRC_DIR/cromwell.conf
+--workflow-options   Local path to `workflow_options.json`. DEFAULT \$SRC_DIR/workflow_options.json
 --machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
 
 Additional arguments are passed directly to gsutil compute instances
@@ -99,8 +99,8 @@ MACHINE_TYPE=${MACHINE_TYPE:-"e2-standard-2"}
 
 [ -z $SERVER_ACCOUNT   ] && die "Missing argument --server-account"
 [ -z $PROJECT          ] && die "Missing argument --project"
-[ -z $CROMWELL_CONF    ] && CROMWELL_CONF="$src_dir/cromwell.conf"
-[ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$src_dir/workflow_options.json"
+[ -z $CROMWELL_CONF    ] && CROMWELL_CONF="$SRC_DIR/cromwell.conf"
+[ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$SRC_DIR/workflow_options.json"
 
 if [[ ! -f $CROMWELL_CONF ]]; then
     cat <<EOF

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -11,7 +11,7 @@ $0 - Start a new Cromwell VM instance
 usage: $0 INSTANCE_NAME [--argument value]*
 
 arguments:
--h, --help           print this block and immediately exits
+-h, --help           prints this block and immediately exits
 --project            GCP project name
 --server-account     Email identifier of service account used by main Cromwell instance
 --cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT \$SRC_DIR/cromwell.conf

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -102,7 +102,6 @@ MACHINE_TYPE=${MACHINE_TYPE:-"e2-standard-2"}
 [ -z $CROMWELL_CONF    ] && CROMWELL_CONF="$src_dir/cromwell.conf"
 [ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$src_dir/workflow_options.json"
 
-
 if [[ ! -f $CROMWELL_CONF ]]; then
     cat <<EOF
 cromwell.conf does not exist. Check passed value or generate via

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -17,6 +17,7 @@ arguments:
 --cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT \$SRC_DIR/cromwell.conf
 --workflow-options   Local path to workflow_options.json. DEFAULT \$SRC_DIR/workflow_options.json
 --machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
+--zone		     DEFAULT us-central1-c. For options, visit: https://cloud.google.com/compute/docs/regions-zones 
 
 Additional arguments are passed directly to gsutil compute instances
 create command. For more information on those arguments, check that commands
@@ -88,6 +89,14 @@ while test $# -gt 0; do
                 shift
             fi
             ;;
+        --zone*)
+            if [ ! "$2" ]; then
+		ZONE="us-central1-c"
+            else
+                ZONE=$2
+                shift
+            fi
+            ;;
         *)
             break
             ;;
@@ -101,6 +110,7 @@ MACHINE_TYPE=${MACHINE_TYPE:-"e2-standard-2"}
 [ -z $PROJECT          ] && die "Missing argument --project"
 [ -z $CROMWELL_CONF    ] && CROMWELL_CONF="$SRC_DIR/cromwell.conf"
 [ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$SRC_DIR/workflow_options.json"
+[ -z $ZONE             ] && ZONE="us-central1-c"
 
 if [[ ! -f $CROMWELL_CONF ]]; then
     cat <<EOF
@@ -122,11 +132,13 @@ EOF
     exit 1
 fi
 
+# $@ indicates the ability to add any of the other flags that come with gcloud compute instances creat
+# for a full account, visit https://cloud.google.com/sdk/gcloud/reference/compute/instances/create
 gcloud compute instances create $INSTANCE_NAME \
        --project $PROJECT \
        --image-family debian-11 \
        --image-project debian-cloud \
-       --zone us-central1-c \
+       --zone $ZONE \
        --machine-type=$MACHINE_TYPE \
        --service-account=$SERVER_ACCOUNT --scopes=cloud-platform \
        --network=$NETWORK --subnet=$SUBNET \

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -17,7 +17,7 @@ arguments:
 --cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT \$SRC_DIR/cromwell.conf
 --workflow-options   Local path to workflow_options.json. DEFAULT \$SRC_DIR/workflow_options.json
 --machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
---zone		     DEFAULT us-central1-c. For options, visit: https://cloud.google.com/compute/docs/regions-zones 
+--zone               DEFAULT us-central1-c. For options, visit: https://cloud.google.com/compute/docs/regions-zones 
 
 Additional arguments are passed directly to gsutil compute instances
 create command. For more information on those arguments, check that commands

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -11,11 +11,12 @@ $0 - Start a new Cromwell VM instance
 usage: $0 INSTANCE_NAME [--argument value]*
 
 arguments:
--h, --help         print this block and immediately exits
---project          GCP project name
---server-account   Email identifier of service account used by main Cromwell instance
---cromwell-conf    Local path to configuration file for Cromwell server. DEFAULT $SRC_DIR/cromwell.conf
---machine-type     GCP machine type for the instance. DEFAULT e2-standard-2
+-h, --help           print this block and immediately exits
+--project            GCP project name
+--server-account     Email identifier of service account used by main Cromwell instance
+--cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT $SRC_DIR/cromwell.conf
+--workflow-options   Local path to `workflow_options.json`. DEFAULT $SRC_DIR/workflow_options.json
+--machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
 
 Additional arguments are passed directly to gsutil compute instances
 create command. For more information on those arguments, check that commands
@@ -47,6 +48,22 @@ while test $# -gt 0; do
             show_help
             exit 0
             ;;
+        --cromwell-conf*)
+            if [ ! "$2" ]; then
+                CROMWELL_CONF="$SRC_DIR/cromwell.conf"
+            else
+                CROMWELL_CONF=$2
+                shift
+            fi
+            ;;
+	 --workflow-dir*)
+            if [ ! "$2" ]; then
+                WORKFLOW_OPTIONS="$SRC_DIR/workflow_options.json"
+            else
+                WORKFLOW_OPTIONS=$2
+                shift
+            fi
+            ;; 
         --project*)
             if [ ! "$2" ]; then
                 die 'Error: "--project" requires a string argument for the GCP project name used'
@@ -80,10 +97,12 @@ done
 
 MACHINE_TYPE=${MACHINE_TYPE:-"e2-standard-2"}
 
-[ -z $SERVER_ACCOUNT ] && die "Missing argument --server-account"
-[ -z $PROJECT        ] && die "Missing argument --project"
+[ -z $SERVER_ACCOUNT   ] && die "Missing argument --server-account"
+[ -z $PROJECT          ] && die "Missing argument --project"
+[ -z $CROMWELL_CONF    ] && CROMWELL_CONF="$src_dir/cromwell.conf"
+[ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$src_dir/workflow_options.json"
 
-CROMWELL_CONF="$SRC_DIR/cromwell.conf"
+
 if [[ ! -f $CROMWELL_CONF ]]; then
     cat <<EOF
 cromwell.conf does not exist. Check passed value or generate via
@@ -94,7 +113,6 @@ EOF
     exit 1
 fi
 
-WORKFLOW_OPTIONS="$SRC_DIR/workflow_options.json"
 if [[ ! -f $WORKFLOW_OPTIONS ]]; then
     cat <<EOF
 workflow_options.json does not exist. Check passed value or generate via

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -15,7 +15,7 @@ arguments:
 --project            GCP project name
 --server-account     Email identifier of service account used by main Cromwell instance
 --cromwell-conf      Local path to configuration file for Cromwell server. DEFAULT \$SRC_DIR/cromwell.conf
---workflow-options   Local path to `workflow_options.json`. DEFAULT \$SRC_DIR/workflow_options.json
+--workflow-options   Local path to workflow_options.json. DEFAULT \$SRC_DIR/workflow_options.json
 --machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
 
 Additional arguments are passed directly to gsutil compute instances

--- a/scripts/cloudize-workflow.py
+++ b/scripts/cloudize-workflow.py
@@ -293,6 +293,12 @@ def cloudize(bucket, wf_path, inputs_path, output_path, dryrun=False):
     and its workflow's CWL definition."""
     workflow = make_workflow(wf_path, inputs_path)
     file_inputs = workflow.find_file_inputs()
+
+    if (not bool(file_inputs)):
+        logging.error(f"file_inputs is empty {file_inputs}. "
+        "Check that your LSF_DOCKER_VOLUMES is set up correctly within your .bashrc")
+        exit()
+
     set_cloud_paths(file_inputs)
     cloudized_inputs = cloudize_file_paths(workflow.inputs, bucket, file_inputs)
     write_new_inputs(cloudized_inputs, output_path)

--- a/scripts/cloudize-workflow.py
+++ b/scripts/cloudize-workflow.py
@@ -296,7 +296,7 @@ def cloudize(bucket, wf_path, inputs_path, output_path, dryrun=False):
 
     if (not bool(file_inputs)):
         logging.error(f"file_inputs is empty {file_inputs}. "
-        "Check that your LSF_DOCKER_VOLUMES is set up correctly within your .bashrc")
+        "Check that your input files are properly accessbile.")
         exit()
 
     set_cloud_paths(file_inputs)

--- a/scripts/create_resources.sh
+++ b/scripts/create_resources.sh
@@ -60,6 +60,7 @@ gcloud compute firewall-rules create $NETWORK-allow-ssh \
        --allow tcp:22
 
 # Bucket
+gsutil mb --retention 30d gs://$BUCKET
 gsutil mb -p $PROJECT -b on gs://$BUCKET
 gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:objectAdmin gs://$BUCKET
 gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:legacyBucketOwner gs://$BUCKET

--- a/scripts/create_resources.sh
+++ b/scripts/create_resources.sh
@@ -61,7 +61,7 @@ gcloud compute firewall-rules create $NETWORK-allow-ssh \
        --allow tcp:22
 
 # Bucket
-gsutil mb --retention $RETENTION gs://$BUCKET
+[ ! -z $RETENTION ] && gsutil mb --retention $RETENTION gs://$BUCKET
 gsutil mb -p $PROJECT -b on gs://$BUCKET
 gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:objectAdmin gs://$BUCKET
 gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:legacyBucketOwner gs://$BUCKET

--- a/scripts/create_resources.sh
+++ b/scripts/create_resources.sh
@@ -4,7 +4,7 @@ PROJECT=$1
 SERVER_NAME=$2
 COMPUTE_NAME=$3
 BUCKET=$4
-CIDR=$5
+IP_RANGE=$5
 GC_REGION=$6
 
 NETWORK=cloud-workflows
@@ -55,7 +55,7 @@ gcloud compute networks subnets create $SUBNET \
 # Firewall
 gcloud compute firewall-rules create $NETWORK-allow-ssh \
        --project=$PROJECT \
-       --source-ranges $CIDR \
+       --source-ranges $IP_RANGE \
        --network=$NETWORK \
        --allow tcp:22
 

--- a/scripts/create_resources.sh
+++ b/scripts/create_resources.sh
@@ -6,6 +6,7 @@ COMPUTE_NAME=$3
 BUCKET=$4
 IP_RANGE=$5
 GC_REGION=$6
+RETENTION=$7
 
 NETWORK=cloud-workflows
 SUBNET=cloud-workflows-default
@@ -60,7 +61,7 @@ gcloud compute firewall-rules create $NETWORK-allow-ssh \
        --allow tcp:22
 
 # Bucket
-gsutil mb --retention 30d gs://$BUCKET
+gsutil mb --retention $RETENTION gs://$BUCKET
 gsutil mb -p $PROJECT -b on gs://$BUCKET
 gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:objectAdmin gs://$BUCKET
 gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:legacyBucketOwner gs://$BUCKET


### PR DESCRIPTION
resources.sh:
- made the arguments syntax a little more consistent
- added an argument to specify a path for configuration file, defaulting to /$SRC_DIR/

start.sh:
- added arguments for config and workflow options paths, defaulting to /$SRC_DIR/


I tested it and it seemed to be working on my end, but someone else should also test it before merging 